### PR TITLE
Fix deprecated curly braces (PHP8 compliance)

### DIFF
--- a/CRM/CiviFlexmailerEmbedimages/EmbedSender.php
+++ b/CRM/CiviFlexmailerEmbedimages/EmbedSender.php
@@ -163,7 +163,7 @@ class CRM_CiviFlexmailerEmbedimages_EmbedSender extends \Civi\FlexMailer\Listene
       }
 
       // Register 5xx SMTP response code (permanent failure) as bounce.
-      if (isset($code{0}) && $code{0} === '5') {
+      if (isset($code[0]) && $code[0] === '5') {
         return FALSE;
       }
 


### PR DESCRIPTION
Fixes the fatal error in PHP8+:

```
Fatal error: Array and string offset access syntax with curly braces is no longer supported in de.ergomation.civi-flexmailer-embedimages/CRM/CiviFlexmailerEmbedimages/EmbedSender.php on line 166
```